### PR TITLE
Fixed conflict of Prelude <> and PrettyPrint <> in HTypes

### DIFF
--- a/src/HTypes.hs
+++ b/src/HTypes.hs
@@ -7,7 +7,7 @@ module HTypes(HKind(..), HType(..), HSymbol, hTypeToFormula, pHSymbol, pHType, p
         prHSymbolOp,
         htNot, isHTUnion, getHTVars, substHT,
         HClause, HPat, HExpr(HEVar), hPrClause, termToHExpr, termToHClause, getBinderVars) where
-import Text.PrettyPrint.HughesPJ(Doc, renderStyle, style, text, (<>), parens, ($$), vcat, punctuate,
+import Text.PrettyPrint.HughesPJ as THP (Doc, renderStyle, style, text, (<>), parens, ($$), vcat, punctuate,
          sep, fsep, nest, comma, (<+>))
 import Data.Char(isAlphaNum, isAlpha, isUpper)
 import Data.List(union, (\\))
@@ -218,7 +218,7 @@ ppPat :: Int -> HPat -> Doc
 ppPat _ (HPVar s) = text s
 ppPat _ (HPCon s) = text s
 ppPat _ (HPTuple ps) = parens $ fsep $ punctuate comma (map (ppPat 0) ps)
-ppPat _ (HPAt s p) = text s <> text "@" <> ppPat 10 p
+ppPat _ (HPAt s p) = text s THP.<> text "@" THP.<> ppPat 10 p
 ppPat p (HPApply a b) = pparens (p > 1) $ ppPat 1 a <+> ppPat 2 b
 
 ppExpr :: Int -> HExpr -> Doc


### PR DESCRIPTION
To avoid conflicts between <> and <>, the name is now written fully qualified (also an alias has been added)