### PR TITLE
Define return in terms of pure

### DIFF
--- a/src/LJT.hs
+++ b/src/LJT.hs
@@ -140,11 +140,11 @@ nf ee = spine ee []
 newtype P a = P { unP :: PS -> [(PS, a)] }
 
 instance Applicative P where
-    pure = return
+    pure x = P $ \ s -> [(s, x)]
     (<*>) = ap
 
 instance Monad P where
-    return x = P $ \ s -> [(s, x)]
+    return = pure
     P m >>= f = P $ \ s ->
         [ y | (s',x) <- m s, y <- unP (f x) s' ]
 


### PR DESCRIPTION
This silences the following warning with ghc-9.2.8:

src/LJT.hs:143:5: warning: [-Wnoncanonical-monad-instances]
    Noncanonical ‘pure = return’ definition detected
    in the instance declaration for ‘Applicative P’.
    Move definition from ‘return’ to ‘pure’
    See also: https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/monad-of-no-return
    |
143 |     pure = return
    |     ^^^^^^^^^^^^^

src/LJT.hs:147:5: warning: [-Wnoncanonical-monad-instances]
    Noncanonical ‘return’ definition detected
    in the instance declaration for ‘Monad P’.
    ‘return’ will eventually be removed in favour of ‘pure’
    Either remove definition for ‘return’ (recommended) or define as ‘return = pure’
    See also: https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/monad-of-no-return
    |
147 |     return x = P $ \ s -> [(s, x)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^