### PR TITLE
Import liftM2 from Control.Monad

### DIFF
--- a/src/HCheck.hs
+++ b/src/HCheck.hs
@@ -4,6 +4,7 @@
 --
 module HCheck(htCheckEnv, htCheckType) where
 import Data.List(union)
+import Control.Monad(liftM2)
 import Control.Monad.Except()
 import Control.Monad.State
 import Data.IntMap(IntMap, insert, (!), empty)


### PR DESCRIPTION
ghc-9.6.3 doesn't see it in scope. Also checked to build without warning on 9.2.8 and 8.10.7, plus liftA2 seems to not be in scope without an additional import and might not be in base for older ghc/base versions.